### PR TITLE
Web Passthrough for /healthcheck

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ scripts/run-replay-instance.sh 10 [DRY-RUN]
 **Note**: It is important to run this script, as it injects the IP address of the orchestrator node into the replay nodes. Without this script you would need to manually update all the replay nodes with the IP address of the orchestrator.
 
 ## Web Dashboard
-You can see the status of jobs, configuration, and summary of replay status by using the webservice on the orchestrator node. Navigate to `http://orchestor.example.com:4000/`.
+You can see the status of jobs, configuration, and summary of replay status by using the webservice on the orchestrator node. Navigate to `http://orchestor.example.com/`.
 
 Many HTTP calls support HTML, JSON, and Text responses. Look at [HTTP Service Calls](docs/http-service-calls.md) for other URL options and Accept encoding options.
 

--- a/config/nginx-replay-test.conf
+++ b/config/nginx-replay-test.conf
@@ -15,12 +15,12 @@ server {
 	server_name _;
 
   # pass these URLs to app
-	location ~ ^/(status|config|summary) {
+	location ~ ^/(status|config|summary|healthcheck) {
     proxy_buffering off;
     proxy_pass http://127.0.0.1:4000;
 	}
 
-  # everything else serve static content 
+  # everything else serve static content
   location / {
     try_files $uri $uri/ =404;
   }

--- a/docs/AWS-Host-Setup.md
+++ b/docs/AWS-Host-Setup.md
@@ -4,8 +4,8 @@
 - We use unbuntu 22.04 OS on a t2.micro instance.
 - You need to setup a private key for your host to support SSH.
 - IAM access allows the node to spin up relay nodes on the command line via `aws ec2 run-instances`
-- Security group opens port 4000 to private IP from replay Nodes
-- Security group opens port 4000 and SSH to administrator IPs (Your IP)
+- Security group opens webservice to private IP from replay Nodes
+- Security group opens webservice and SSH to administrator IPs (Your IP)
 - The User Data setup script may be found under [`scripts/orchestrator-bootstrap.sh`](../scripts/orchestrator-bootstrap.sh)
 
 ## Replay Nodes

--- a/docs/http-service-calls.md
+++ b/docs/http-service-calls.md
@@ -4,6 +4,7 @@
 - job - gets/sets configuration data for the replay nodes
 - status - gets a replay nodes progress and state
 - config - get/sets the configuration data used to initialize the job
+- summary - progress of current run and reports any failed jobs
 - healthcheck - gets 200/0K always
 
 ## Job
@@ -48,6 +49,23 @@ For the GET request when there are no parameters return statuses for all jobs. R
 
 ### POST
 When running replay tests we don't always known the expected integrity hash. For example when state database is updated, which may come as part of an update the leap version. For that reason we take the integrity hash, after loading a snapshot, as the known good integrity hash at that block height. The `/config` POST request used the `end_block_num` in the body to look up the configuration slice. Following that the POST updates the configuration in memory and flushes back to disk. This persists the integrity hash as the known good, and expected value at `end_block_num`.
+
+## Summary (Progress)
+
+### GET
+Returns the following
+- number of blocks processed
+- total number of blocks to process
+- jobs completed
+- jobs failed
+- jobs remaining
+
+In addition, lists the failed jobs with the status, links to job details, and config slice.
+
+Content Type Support.
+- If the Accepts header is text-html returns html
+- If Accepts header is application/json returns json
+
 
 ## Healthcheck
 Always returns same value used for healthchecks

--- a/docs/running-tests.md
+++ b/docs/running-tests.md
@@ -21,6 +21,7 @@ sudo apt install -y unzip python3 python3-pip
 pip install datetime argparse werkzeug
 cd orchestration-service/test
 ./run-pytest.sh
+echo $? # expect 0
 ```
 
 ### Details
@@ -42,6 +43,7 @@ sudo apt install -y unzip python3 python3-pip
 pip install datetime argparse werkzeug
 cd replay-client/tests
 ./run.sh
+echo $? # expect 0
 ```
 
 ### Details


### PR DESCRIPTION
Allow nginx to pass `/healthcheck` to underlying app service. Update documentation for summary-progress api.