### PR TITLE
Set Status to ERROR when snapshot uncompression fails

### DIFF
--- a/replay-client/replay-node-cleanup.sh
+++ b/replay-client/replay-node-cleanup.sh
@@ -17,6 +17,7 @@ done
 
 # remove data
 rm -rf /data/nodeos
+rm /tmp/job.conf.json
 
 # remove package
 rm /home/${USER:?}/*.deb

--- a/replay-client/start-nodeos-run-replay.sh
+++ b/replay-client/start-nodeos-run-replay.sh
@@ -139,7 +139,7 @@ if [ $START_BLOCK -gt 0 ] && [ -f "${NODEOS_DIR}"/snapshot/snapshot.bin.zst ]; t
   echo "Unzip snapshot"
   zstd --decompress "${NODEOS_DIR}"/snapshot/snapshot.bin.zst
   # sometimes compression format is bad error out on failure
-  if [ $? != 0 ]; then
+  if [ $? -ne 0 ]; then
     echo "Failed to unzip snapshot"
     trap_exit
   fi

--- a/replay-client/start-nodeos-run-replay.sh
+++ b/replay-client/start-nodeos-run-replay.sh
@@ -142,6 +142,14 @@ echo "Restoring Blocks.log from Cloud Storage"
 if [ $START_BLOCK -gt 0 ] && [ -f "${NODEOS_DIR}"/snapshot/snapshot.bin.zst ]; then
   echo "Unzip snapshot"
   zstd --decompress "${NODEOS_DIR}"/snapshot/snapshot.bin.zst
+  # sometimes compression format is bad error out on failure
+  if [ $? != 0 ]; then
+    python3 "${REPLAY_CLIENT_DIR:?}"/job_operations.py --host ${ORCH_IP} --port ${ORCH_PORT} \
+        --operation update-status --status "ERROR" --job-id ${JOBID}
+    echo "Error uncompressing ${SNAPSHOT_PATH}"
+    [ -f "$LOCK_FILE" ] && rm "$LOCK_FILE"
+    exit 1
+  fi
 fi
 
 ## update status that snapshot is loading ##

--- a/replay-client/start-nodeos-run-replay.sh
+++ b/replay-client/start-nodeos-run-replay.sh
@@ -90,7 +90,7 @@ echo "Step 2 of 8: Getting job details from orchestration service"
 python3 "${REPLAY_CLIENT_DIR:?}"/job_operations.py --host ${ORCH_IP} --port ${ORCH_PORT} --operation pop > /tmp/job.conf.json
 
 # if json result is empty failed to aquire job
-if [ ! -s /tmp/job.conf.json ]; then
+if [[ ! -e "/tmp/job.conf.json" || ! -s "/tmp/job.conf.json" ]]; then
   echo "Failed to aquire job"
   trap_exit
 fi


### PR DESCRIPTION
Resolved #62 
Sometimes the snapshot is bad and can't be uncompressed. Abort early and set job status to `ERROR`