### PR TITLE
Update Manifest Generation and Jan 2024 Manfiest File

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Select `LowEndOrchestrator` and use the default template.
 ![OrchTemplaceSelect](docs/images/CDOrchTemplateSelect.png)
 
 ## Updating Orchestrator Job Configuration
-By default the setup will spin up a webservice with [Production Run from Nov 2023](meta-data/full-production-run-20231130.json). To change the job configuration you need to create your own JSON configuration, and restart the service to use the new JSON. **Note** need to use `nohup` on python webservice to keep the process running after ssh-shell exit.
+By default the setup will spin up a webservice with [Production Run from Jan 2024](meta-data/full-production-run-20240101.json). To change the job configuration you need to create your own JSON configuration, and restart the service to use the new JSON. **Note** need to use `nohup` on python webservice to keep the process running after ssh-shell exit.
 - Create your own JSON following the example formate from `test-simple-jobs.json`
 - Upload the file to the orchestrator node
 - Log into the orchestrator node as `ubuntu` user
@@ -61,10 +61,10 @@ See [Operating Details](docs/operating-details.md) for list of scripts, logs, an
 For testing options see [Running Tests](docs/running-tests.md)
 
 ## Generating Manifests
-The python script `replay-test/scripts/manifest/generate_manifest_from_eosnation.py` will build a manifest off the list of eos nation snapshots. A manifest may be validated for valid JSON and a contiguous block range using the [validate_manifest.py](scripts/manifest/validate_manifest.py) script
+The python script `replay-test/scripts/manifest/generate_manifest.py` will build a manifest off either the snapshots listed in S3 or the list of eos nation snapshots. By default connects to S3 to build snapshot list, and requires `aws cli` and read permissions. A manifest may be validated for valid JSON and a contiguous block range using the [validate_manifest.py](scripts/manifest/validate_manifest.py) script
 
 Redirect of stdout is recommended to separate the debug messages printed on stderr
-`python3 generate_manifest_from_eosnation.py --source-net mainnet 1> ./manifest-config.json`  
+`python3 generate_manifest.py --source-net mainnet 1> ./manifest-config.json`  
 
 ### Options
 In this release `block-space-between-slices`, `max-block-height`, and `min-block-height`.
@@ -72,6 +72,7 @@ In this release `block-space-between-slices`, `max-block-height`, and `min-block
 - `--source-net` Defaults to `mainnet`. Which chain to target. Options include mainnet, kylin, and jungle
 - `--leap-version` Defaults to `5.0.0`. Specify the version of leap to use from the builds
 - `--snapshot-version` Defaults to v6.
+- `--source-eosnation` Build manifest from eos-nation webpage of snapshots
 - `--upload-snapshots` Flag takes no values, and defaults to false. This uploads snapshots to AWS S3. Must have `aws cli` and permission to upload.
 - `--block-space-between-slices` Min number of blocks between slices, cuts down on the number of slices created
 - `--max-block-height` Limits manifest by not processing starting block ranges above value

--- a/meta-data/full-production-run-20240101.json
+++ b/meta-data/full-production-run-20240101.json
@@ -1,0 +1,5330 @@
+[
+    {
+        "start_block_id": 0,
+        "end_block_id": 15819,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2018-06-10-01-eos-v6-0000000000.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 15819,
+        "end_block_id": 1415312,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2018-06-10-13-eos-v6-0000015819.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 1415312,
+        "end_block_id": 2472388,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2018-06-18-20-eos-v6-1415312.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 2472388,
+        "end_block_id": 3620905,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2018-06-24-23-eos-v6-2472388.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 3620905,
+        "end_block_id": 4272180,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2018-07-01-15-eos-v6-3620905.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 4272180,
+        "end_block_id": 4963457,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2018-07-05-09-eos-v6-4272180.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 4963457,
+        "end_block_id": 6081514,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2018-07-09-10-eos-v6-4963457.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 6081514,
+        "end_block_id": 7757811,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2018-07-15-22-eos-v6-6081514.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 7757811,
+        "end_block_id": 8407823,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2018-07-25-20-eos-v6-7757811.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 8407823,
+        "end_block_id": 10108872,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2018-07-29-16-eos-v6-8407823.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 10108872,
+        "end_block_id": 10789559,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2018-08-08-17-eos-v6-10108872.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 10789559,
+        "end_block_id": 11985820,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2018-08-12-18-eos-v6-10789559.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 11985820,
+        "end_block_id": 12561289,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2018-08-19-19-eos-v6-11985820.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 12561289,
+        "end_block_id": 13093213,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2018-08-23-03-eos-v6-12561289.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 13093213,
+        "end_block_id": 13725317,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2018-08-26-05-eos-v6-13093213.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 13725317,
+        "end_block_id": 14402234,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2018-08-29-22-eos-v6-13725317.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 14402234,
+        "end_block_id": 15597012,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2018-09-02-21-eos-v6-14402234.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 15597012,
+        "end_block_id": 16150309,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2018-09-09-22-eos-v6-15597012.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 16150309,
+        "end_block_id": 17323276,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2018-09-13-05-eos-v6-16150309.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 17323276,
+        "end_block_id": 17977332,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2018-09-20-00-eos-v6-17323276.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 17977332,
+        "end_block_id": 19216804,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2018-09-23-19-eos-v6-17977332.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 19216804,
+        "end_block_id": 19746419,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2018-09-30-23-eos-v6-19216804.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 19746419,
+        "end_block_id": 20927422,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2018-10-04-01-eos-v6-19746419.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 20927422,
+        "end_block_id": 21595055,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2018-10-10-21-eos-v6-20927422.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 21595055,
+        "end_block_id": 22789333,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2018-10-14-18-eos-v6-21595055.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 22789333,
+        "end_block_id": 23309367,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2018-10-21-16-eos-v6-22789333.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 23309367,
+        "end_block_id": 24514330,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2018-10-24-16-eos-v6-23309367.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 24514330,
+        "end_block_id": 25203102,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2018-10-31-16-eos-v6-24514330.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 25203102,
+        "end_block_id": 26404282,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2018-11-04-16-eos-v6-25203102.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 26404282,
+        "end_block_id": 26924911,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2018-11-11-16-eos-v6-26404282.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 26924911,
+        "end_block_id": 28128160,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2018-11-14-16-eos-v6-26924911.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 28128160,
+        "end_block_id": 28817299,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2018-11-21-16-eos-v6-28128160.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 28817299,
+        "end_block_id": 30017599,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2018-11-25-17-eos-v6-28817299.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 30017599,
+        "end_block_id": 30531499,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2018-12-02-16-eos-v6-30017599.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 30531499,
+        "end_block_id": 31736134,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2018-12-05-16-eos-v6-30531499.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 31736134,
+        "end_block_id": 32437618,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2018-12-12-16-eos-v6-31736134.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 32437618,
+        "end_block_id": 33627569,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2018-12-16-18-eos-v6-32437618.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 33627569,
+        "end_block_id": 34144219,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2018-12-23-16-eos-v6-33627569.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 34144219,
+        "end_block_id": 35352254,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2018-12-26-16-eos-v6-34144219.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 35352254,
+        "end_block_id": 36033996,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2019-01-02-16-eos-v6-35352254.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 36033996,
+        "end_block_id": 37239521,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2019-01-06-16-eos-v6-36033996.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 37239521,
+        "end_block_id": 37756798,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2019-01-13-16-eos-v6-37239521.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 37756798,
+        "end_block_id": 38971069,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2019-01-16-15-eos-v6-37756798.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 38971069,
+        "end_block_id": 39660905,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2019-01-23-16-eos-v6-38971069.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 39660905,
+        "end_block_id": 40869285,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2019-01-27-16-eos-v6-39660905.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 40869285,
+        "end_block_id": 41379115,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2019-02-03-17-eos-v6-40869285.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 41379115,
+        "end_block_id": 42595347,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2019-02-06-16-eos-v6-41379115.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 42595347,
+        "end_block_id": 43280237,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2019-02-13-17-eos-v6-42595347.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 43280237,
+        "end_block_id": 44499337,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2019-02-17-16-eos-v6-43280237.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 44499337,
+        "end_block_id": 45007281,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2019-02-24-18-eos-v6-44499337.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 45007281,
+        "end_block_id": 46223127,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2019-02-27-16-eos-v6-45007281.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 46223127,
+        "end_block_id": 46911265,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2019-03-06-17-eos-v6-46223127.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 46911265,
+        "end_block_id": 48116875,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2019-03-10-17-eos-v6-46911265.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 48116875,
+        "end_block_id": 48630019,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2019-03-17-17-eos-v6-48116875.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 48630019,
+        "end_block_id": 49844181,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2019-03-20-16-eos-v6-48630019.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 49844181,
+        "end_block_id": 50529064,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2019-03-27-17-eos-v6-49844181.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 50529064,
+        "end_block_id": 51739244,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2019-03-31-16-eos-v6-50529064.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 51739244,
+        "end_block_id": 52255713,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2019-04-07-16-eos-v6-51739244.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 52255713,
+        "end_block_id": 53470349,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2019-04-10-16-eos-v6-52255713.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 53470349,
+        "end_block_id": 54166290,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2019-04-17-16-eos-v6-53470349.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 54166290,
+        "end_block_id": 55368568,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2019-04-21-17-eos-v6-54166290.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 55368568,
+        "end_block_id": 55893955,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2019-04-28-16-eos-v6-55368568.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 55893955,
+        "end_block_id": 57096925,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2019-05-01-17-eos-v6-55893955.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 57096925,
+        "end_block_id": 57784933,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2019-05-08-16-eos-v6-57096925.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 57784933,
+        "end_block_id": 58998835,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2019-05-12-16-eos-v6-57784933.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 58998835,
+        "end_block_id": 59518925,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2019-05-19-17-eos-v6-58998835.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 59518925,
+        "end_block_id": 60719062,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2019-05-22-17-eos-v6-59518925.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 60719062,
+        "end_block_id": 61420979,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2019-05-29-16-eos-v6-60719062.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 61420979,
+        "end_block_id": 62625741,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2019-06-02-17-eos-v6-61420979.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 62625741,
+        "end_block_id": 63141588,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2019-06-09-17-eos-v6-62625741.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 63141588,
+        "end_block_id": 64346152,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2019-06-12-17-eos-v6-63141588.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 64346152,
+        "end_block_id": 65047033,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2019-06-19-16-eos-v6-64346152.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 65047033,
+        "end_block_id": 66246844,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2019-06-23-17-eos-v6-65047033.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 66246844,
+        "end_block_id": 66773322,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2019-06-30-16-eos-v6-66246844.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 66773322,
+        "end_block_id": 67976492,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2019-07-03-17-eos-v6-66773322.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 67976492,
+        "end_block_id": 68664955,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2019-07-10-17-eos-v6-67976492.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 68664955,
+        "end_block_id": 69871994,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2019-07-14-17-eos-v6-68664955.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 69871994,
+        "end_block_id": 70382987,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2019-07-21-17-eos-v6-69871994.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 70382987,
+        "end_block_id": 71599128,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2019-07-24-16-eos-v6-70382987.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 71599128,
+        "end_block_id": 72282117,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2019-07-31-17-eos-v6-71599128.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 72282117,
+        "end_block_id": 73499127,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2019-08-04-16-eos-v6-72282117.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 73499127,
+        "end_block_id": 74005371,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2019-08-11-17-eos-v6-73499127.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 74005371,
+        "end_block_id": 75214247,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2019-08-14-16-eos-v6-74005371.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 75214247,
+        "end_block_id": 75914987,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2019-08-21-16-eos-v6-75214247.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 75914987,
+        "end_block_id": 75917025,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2019-08-25-17-eos-v6-75914987.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 75917025,
+        "end_block_id": 77123941,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2019-08-25-17-eos-v6-75917025.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 77123941,
+        "end_block_id": 77636035,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2019-09-01-17-eos-v6-77123941.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 77636035,
+        "end_block_id": 78840452,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2019-09-04-17-eos-v6-77636035.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 78840452,
+        "end_block_id": 79535817,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2019-09-11-16-eos-v6-78840452.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 79535817,
+        "end_block_id": 80735832,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2019-09-15-17-eos-v6-79535817.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 80735832,
+        "end_block_id": 81248838,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2019-09-22-16-eos-v6-80735832.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 81248838,
+        "end_block_id": 82469692,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2019-09-25-16-eos-v6-81248838.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 82469692,
+        "end_block_id": 83152308,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2019-10-02-18-eos-v6-82469692.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 83152308,
+        "end_block_id": 84362040,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2019-10-06-16-eos-v6-83152308.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 84362040,
+        "end_block_id": 84877218,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2019-10-13-17-eos-v6-84362040.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 84877218,
+        "end_block_id": 86090764,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2019-10-16-16-eos-v6-84877218.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 86090764,
+        "end_block_id": 86776429,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2019-10-23-17-eos-v6-86090764.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 86776429,
+        "end_block_id": 87984263,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2019-10-27-16-eos-v6-86776429.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 87984263,
+        "end_block_id": 88501817,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2019-11-03-16-eos-v6-87984263.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 88501817,
+        "end_block_id": 89299329,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2019-11-06-16-eos-v6-88501817.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 89299329,
+        "end_block_id": 89695971,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2019-11-11-08-eos-v6-89299329.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 89695971,
+        "end_block_id": 90375067,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2019-11-13-16-eos-v6-89695971.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 90375067,
+        "end_block_id": 90772611,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2019-11-17-16-eos-v6-90375067.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 90772611,
+        "end_block_id": 91567826,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2019-11-20-00-eos-v6-90772611.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 91567826,
+        "end_block_id": 92078277,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2019-11-24-16-eos-v6-91567826.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 92078277,
+        "end_block_id": 92870447,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2019-11-27-16-eos-v6-92078277.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 92870447,
+        "end_block_id": 93267592,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2019-12-02-07-eos-v6-92870447.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 93267592,
+        "end_block_id": 93949568,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2019-12-04-16-eos-v6-93267592.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 93949568,
+        "end_block_id": 94248971,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2019-12-08-16-eos-v6-93949568.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 94248971,
+        "end_block_id": 94847351,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2019-12-10-10-eos-v6-94248971.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 94847351,
+        "end_block_id": 95147542,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2019-12-13-21-eos-v6-94847351.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 95147542,
+        "end_block_id": 95656033,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2019-12-15-16-eos-v6-95147542.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 95656033,
+        "end_block_id": 95951332,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2019-12-18-16-eos-v6-95656033.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 95951332,
+        "end_block_id": 96540277,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2019-12-20-10-eos-v6-95951332.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 96540277,
+        "end_block_id": 96833894,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2019-12-23-22-eos-v6-96540277.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 96833894,
+        "end_block_id": 97513362,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2019-12-25-16-eos-v6-96833894.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 97513362,
+        "end_block_id": 97751917,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2019-12-29-16-eos-v6-97513362.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 97751917,
+        "end_block_id": 98225079,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2019-12-31-01-eos-v6-97751917.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 98225079,
+        "end_block_id": 98463209,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-01-02-20-eos-v6-98225079.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 98463209,
+        "end_block_id": 98951216,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-01-04-06-eos-v6-98463209.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 98951216,
+        "end_block_id": 99203765,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-01-07-04-eos-v6-98951216.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 99203765,
+        "end_block_id": 99672416,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-01-08-16-eos-v6-99203765.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 99672416,
+        "end_block_id": 99906936,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-01-11-10-eos-v6-99672416.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 99906936,
+        "end_block_id": 100375340,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-01-12-20-eos-v6-99906936.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 100375340,
+        "end_block_id": 100575722,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-01-15-16-eos-v6-100375340.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 100575722,
+        "end_block_id": 100975753,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-01-16-21-eos-v6-100575722.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 100975753,
+        "end_block_id": 101181539,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-01-19-16-eos-v6-100975753.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 101181539,
+        "end_block_id": 101595173,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-01-21-00-eos-v6-101181539.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 101595173,
+        "end_block_id": 101802019,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-01-23-21-eos-v6-101595173.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 101802019,
+        "end_block_id": 102239535,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-01-25-07-eos-v6-101802019.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 102239535,
+        "end_block_id": 102472131,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-01-28-03-eos-v6-102239535.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 102472131,
+        "end_block_id": 102932000,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-01-29-16-eos-v6-102472131.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 102932000,
+        "end_block_id": 103163903,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-02-01-13-eos-v6-102932000.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 103163903,
+        "end_block_id": 103622471,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-02-02-21-eos-v6-103163903.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 103622471,
+        "end_block_id": 103844436,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-02-05-16-eos-v6-103622471.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 103844436,
+        "end_block_id": 104288436,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-02-07-00-eos-v6-103844436.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 104288436,
+        "end_block_id": 104529198,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-02-09-16-eos-v6-104288436.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 104529198,
+        "end_block_id": 105009661,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-02-11-01-eos-v6-104529198.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 105009661,
+        "end_block_id": 105252248,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-02-13-20-eos-v6-105009661.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 105252248,
+        "end_block_id": 105504556,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-02-15-06-eos-v6-105252248.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 105504556,
+        "end_block_id": 106008023,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-02-16-17-eos-v6-105504556.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 106008023,
+        "end_block_id": 106209071,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-02-19-16-eos-v6-106008023.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 106209071,
+        "end_block_id": 106409312,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-02-20-20-eos-v6-106209071.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 106409312,
+        "end_block_id": 106610475,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-02-22-00-eos-v6-106409312.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 106610475,
+        "end_block_id": 106812743,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-02-23-04-eos-v6-106610475.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 106812743,
+        "end_block_id": 106813174,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-02-24-08-eos-v6-106812743.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 106813174,
+        "end_block_id": 107013097,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-02-24-08-eos-v6-106813174.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 107013097,
+        "end_block_id": 107214088,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-02-25-12-eos-v6-107013097.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 107214088,
+        "end_block_id": 107442902,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-02-26-16-eos-v6-107214088.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 107442902,
+        "end_block_id": 107671998,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-02-27-23-eos-v6-107442902.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 107671998,
+        "end_block_id": 107901720,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-02-29-08-eos-v6-107671998.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 107901720,
+        "end_block_id": 108103364,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-03-01-16-eos-v6-107901720.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 108103364,
+        "end_block_id": 108303565,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-03-02-20-eos-v6-108103364.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 108303565,
+        "end_block_id": 108705287,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-03-04-00-eos-v6-108303565.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 108705287,
+        "end_block_id": 108905905,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-03-06-08-eos-v6-108705287.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 108905905,
+        "end_block_id": 109365659,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-03-07-12-eos-v6-108905905.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 109365659,
+        "end_block_id": 109623622,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-03-10-04-eos-v6-109365659.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 109623622,
+        "end_block_id": 110224817,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-03-11-16-eos-v6-109623622.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 110224817,
+        "end_block_id": 110524192,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-03-15-04-eos-v6-110224817.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 110524192,
+        "end_block_id": 110961475,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-03-16-22-eos-v6-110524192.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 110961475,
+        "end_block_id": 111099023,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-03-19-11-eos-v6-110961475.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 111099023,
+        "end_block_id": 111375621,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-03-20-06-eos-v6-111099023.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 111375621,
+        "end_block_id": 111648611,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-03-21-20-eos-v6-111375621.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 111648611,
+        "end_block_id": 111781693,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-03-23-10-eos-v6-111648611.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 111781693,
+        "end_block_id": 112050652,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-03-24-05-eos-v6-111781693.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 112050652,
+        "end_block_id": 112319655,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-03-25-18-eos-v6-112050652.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 112319655,
+        "end_block_id": 112453978,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-03-27-08-eos-v6-112319655.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 112453978,
+        "end_block_id": 112722923,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-03-28-02-eos-v6-112453978.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 112722923,
+        "end_block_id": 112981483,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-03-29-16-eos-v6-112722923.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 112981483,
+        "end_block_id": 113110960,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-03-31-04-eos-v6-112981483.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 113110960,
+        "end_block_id": 113374075,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-03-31-22-eos-v6-113110960.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 113374075,
+        "end_block_id": 113642515,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-04-02-10-eos-v6-113374075.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 113642515,
+        "end_block_id": 113777054,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-04-03-23-eos-v6-113642515.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 113777054,
+        "end_block_id": 114046389,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-04-04-18-eos-v6-113777054.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 114046389,
+        "end_block_id": 114314387,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-04-06-08-eos-v6-114046389.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 114314387,
+        "end_block_id": 114448877,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-04-07-21-eos-v6-114314387.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 114448877,
+        "end_block_id": 114725271,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-04-08-16-eos-v6-114448877.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 114725271,
+        "end_block_id": 115001937,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-04-10-06-eos-v6-114725271.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 115001937,
+        "end_block_id": 115139145,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-04-11-20-eos-v6-115001937.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 115139145,
+        "end_block_id": 115408866,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-04-12-15-eos-v6-115139145.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 115408866,
+        "end_block_id": 115676680,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-04-14-05-eos-v6-115408866.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 115676680,
+        "end_block_id": 115811280,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-04-15-18-eos-v6-115676680.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 115811280,
+        "end_block_id": 116080156,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-04-16-13-eos-v6-115811280.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 116080156,
+        "end_block_id": 116348995,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-04-18-02-eos-v6-116080156.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 116348995,
+        "end_block_id": 116477720,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-04-19-16-eos-v6-116348995.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 116477720,
+        "end_block_id": 116736876,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-04-20-09-eos-v6-116477720.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 116736876,
+        "end_block_id": 116975601,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-04-21-22-eos-v6-116736876.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 116975601,
+        "end_block_id": 117084708,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-04-23-07-eos-v6-116975601.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 117084708,
+        "end_block_id": 117303972,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-04-23-22-eos-v6-117084708.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 117303972,
+        "end_block_id": 117523397,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-04-25-05-eos-v6-117303972.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 117523397,
+        "end_block_id": 117632326,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-04-26-11-eos-v6-117523397.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 117632326,
+        "end_block_id": 117852176,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-04-27-02-eos-v6-117632326.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 117852176,
+        "end_block_id": 118070647,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-04-28-09-eos-v6-117852176.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 118070647,
+        "end_block_id": 118185391,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-04-29-16-eos-v6-118070647.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 118185391,
+        "end_block_id": 118416110,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-04-30-07-eos-v6-118185391.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 118416110,
+        "end_block_id": 118646283,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-05-01-16-eos-v6-118416110.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 118646283,
+        "end_block_id": 118762217,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-05-02-23-eos-v6-118646283.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 118762217,
+        "end_block_id": 118982086,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-05-03-16-eos-v6-118762217.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 118982086,
+        "end_block_id": 119201452,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-05-04-22-eos-v6-118982086.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 119201452,
+        "end_block_id": 119311033,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-05-06-05-eos-v6-119201452.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 119311033,
+        "end_block_id": 119530965,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-05-06-20-eos-v6-119311033.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 119530965,
+        "end_block_id": 119751451,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-05-08-02-eos-v6-119530965.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 119751451,
+        "end_block_id": 119860575,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-05-09-09-eos-v6-119751451.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 119860575,
+        "end_block_id": 120001209,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-05-10-00-eos-v6-119860575.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 120001209,
+        "end_block_id": 120359757,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-05-10-20-eos-v6-120001209.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 120359757,
+        "end_block_id": 120489010,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-05-12-22-eos-v6-120359757.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 120489010,
+        "end_block_id": 120730650,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-05-13-15-eos-v6-120489010.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 120730650,
+        "end_block_id": 120973674,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-05-15-01-eos-v6-120730650.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 120973674,
+        "end_block_id": 121093944,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-05-16-11-eos-v6-120973674.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 121093944,
+        "end_block_id": 121336347,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-05-17-04-eos-v6-121093944.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 121336347,
+        "end_block_id": 121577787,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-05-18-13-eos-v6-121336347.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 121577787,
+        "end_block_id": 121698440,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-05-19-23-eos-v6-121577787.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 121698440,
+        "end_block_id": 121929143,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-05-20-15-eos-v6-121698440.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 121929143,
+        "end_block_id": 122159222,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-05-22-00-eos-v6-121929143.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 122159222,
+        "end_block_id": 122274681,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-05-23-07-eos-v6-122159222.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 122274681,
+        "end_block_id": 122500222,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-05-24-00-eos-v6-122274681.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 122500222,
+        "end_block_id": 122719535,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-05-25-07-eos-v6-122500222.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 122719535,
+        "end_block_id": 122829862,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-05-26-13-eos-v6-122719535.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 122829862,
+        "end_block_id": 123049379,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-05-27-05-eos-v6-122829862.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 123049379,
+        "end_block_id": 123269282,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-05-28-11-eos-v6-123049379.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 123269282,
+        "end_block_id": 123378838,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-05-29-18-eos-v6-123269282.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 123378838,
+        "end_block_id": 123598609,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-05-30-09-eos-v6-123378838.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 123598609,
+        "end_block_id": 123857967,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-05-31-15-eos-v6-123598609.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 123857967,
+        "end_block_id": 123986951,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-06-02-04-eos-v6-123857967.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 123986951,
+        "end_block_id": 124226388,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-06-02-21-eos-v6-123986951.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 124226388,
+        "end_block_id": 124446183,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-06-04-07-eos-v6-124226388.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 124446183,
+        "end_block_id": 124556707,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-06-05-13-eos-v6-124446183.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 124556707,
+        "end_block_id": 124776513,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-06-06-05-eos-v6-124556707.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 124776513,
+        "end_block_id": 124995815,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-06-07-11-eos-v6-124776513.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 124995815,
+        "end_block_id": 125105941,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-06-08-18-eos-v6-124995815.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 125105941,
+        "end_block_id": 125326202,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-06-09-09-eos-v6-125105941.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 125326202,
+        "end_block_id": 125556576,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-06-10-16-eos-v6-125326202.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 125556576,
+        "end_block_id": 125671742,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-06-12-00-eos-v6-125556576.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 125671742,
+        "end_block_id": 125901642,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-06-12-16-eos-v6-125671742.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 125901642,
+        "end_block_id": 126127149,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-06-13-23-eos-v6-125901642.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 126127149,
+        "end_block_id": 126236849,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-06-15-07-eos-v6-126127149.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 126236849,
+        "end_block_id": 126456500,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-06-15-22-eos-v6-126236849.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 126456500,
+        "end_block_id": 126676256,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-06-17-05-eos-v6-126456500.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 126676256,
+        "end_block_id": 126787042,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-06-18-11-eos-v6-126676256.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 126787042,
+        "end_block_id": 127006701,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-06-19-02-eos-v6-126787042.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 127006701,
+        "end_block_id": 127226238,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-06-20-09-eos-v6-127006701.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 127226238,
+        "end_block_id": 127330319,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-06-21-16-eos-v6-127226238.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 127330319,
+        "end_block_id": 127536969,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-06-22-06-eos-v6-127330319.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 127536969,
+        "end_block_id": 127744809,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-06-23-11-eos-v6-127536969.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 127744809,
+        "end_block_id": 127855060,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-06-24-16-eos-v6-127744809.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 127855060,
+        "end_block_id": 127964332,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-06-25-07-eos-v6-127855060.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 127964332,
+        "end_block_id": 128184375,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-06-25-22-eos-v6-127964332.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 128184375,
+        "end_block_id": 128294361,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-06-27-05-eos-v6-128184375.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 128294361,
+        "end_block_id": 128403933,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-06-27-20-eos-v6-128294361.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 128403933,
+        "end_block_id": 128514288,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-06-28-11-eos-v6-128403933.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 128514288,
+        "end_block_id": 128514580,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-06-29-02-eos-v6-128514288.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 128514580,
+        "end_block_id": 128624801,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-06-29-02-eos-v6-128514580.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 128624801,
+        "end_block_id": 128734355,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-06-29-18-eos-v6-128624801.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 128734355,
+        "end_block_id": 128844600,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-06-30-09-eos-v6-128734355.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 128844600,
+        "end_block_id": 128954024,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-07-01-00-eos-v6-128844600.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 128954024,
+        "end_block_id": 129069418,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-07-01-16-eos-v6-128954024.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 129069418,
+        "end_block_id": 129184325,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-07-02-08-eos-v6-129069418.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 129184325,
+        "end_block_id": 129299199,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-07-03-00-eos-v6-129184325.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 129299199,
+        "end_block_id": 129414394,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-07-03-15-eos-v6-129299199.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 129414394,
+        "end_block_id": 129529425,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-07-04-07-eos-v6-129414394.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 129529425,
+        "end_block_id": 129644702,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-07-04-23-eos-v6-129529425.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 129644702,
+        "end_block_id": 129645053,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-07-05-15-eos-v6-129644702.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 129645053,
+        "end_block_id": 129755635,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-07-05-16-eos-v6-129645053.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 129755635,
+        "end_block_id": 129864512,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-07-06-07-eos-v6-129755635.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 129864512,
+        "end_block_id": 129975476,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-07-06-22-eos-v6-129864512.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 129975476,
+        "end_block_id": 130085228,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-07-07-13-eos-v6-129975476.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 130085228,
+        "end_block_id": 130194662,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-07-08-05-eos-v6-130085228.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 130194662,
+        "end_block_id": 130414392,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-07-08-20-eos-v6-130194662.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 130414392,
+        "end_block_id": 130634478,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-07-10-02-eos-v6-130414392.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 130634478,
+        "end_block_id": 130744773,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-07-11-09-eos-v6-130634478.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 130744773,
+        "end_block_id": 130958331,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-07-12-00-eos-v6-130744773.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 130958331,
+        "end_block_id": 131164907,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-07-13-06-eos-v6-130958331.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 131164907,
+        "end_block_id": 131268982,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-07-14-11-eos-v6-131164907.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 131268982,
+        "end_block_id": 131482702,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-07-15-01-eos-v6-131268982.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 131482702,
+        "end_block_id": 131702195,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-07-16-07-eos-v6-131482702.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 131702195,
+        "end_block_id": 131812586,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-07-17-13-eos-v6-131702195.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 131812586,
+        "end_block_id": 132032674,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-07-18-05-eos-v6-131812586.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 132032674,
+        "end_block_id": 132252067,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-07-19-11-eos-v6-132032674.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 132252067,
+        "end_block_id": 132362292,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-07-20-18-eos-v6-132252067.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 132362292,
+        "end_block_id": 132581971,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-07-21-09-eos-v6-132362292.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 132581971,
+        "end_block_id": 132812287,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-07-22-16-eos-v6-132581971.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 132812287,
+        "end_block_id": 132927110,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-07-24-00-eos-v6-132812287.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 132927110,
+        "end_block_id": 133158173,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-07-24-15-eos-v6-132927110.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 133158173,
+        "end_block_id": 133373524,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-07-26-00-eos-v6-133158173.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 133373524,
+        "end_block_id": 133473984,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-07-27-05-eos-v6-133373524.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 133473984,
+        "end_block_id": 133675754,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-07-27-19-eos-v6-133473984.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 133675754,
+        "end_block_id": 133877775,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-07-28-23-eos-v6-133675754.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 133877775,
+        "end_block_id": 133977840,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-07-30-04-eos-v6-133877775.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 133977840,
+        "end_block_id": 134179198,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-07-30-17-eos-v6-133977840.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 134179198,
+        "end_block_id": 134381331,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-07-31-21-eos-v6-134179198.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 134381331,
+        "end_block_id": 134481859,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-08-02-01-eos-v6-134381331.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 134481859,
+        "end_block_id": 134740949,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-08-02-16-eos-v6-134481859.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 134740949,
+        "end_block_id": 134999883,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-08-04-04-eos-v6-134740949.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 134999883,
+        "end_block_id": 135121179,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-08-05-15-eos-v6-134999883.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 135121179,
+        "end_block_id": 135363059,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-08-06-08-eos-v6-135121179.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 135363059,
+        "end_block_id": 135604607,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-08-07-18-eos-v6-135363059.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 135604607,
+        "end_block_id": 135725554,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-08-09-03-eos-v6-135604607.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 135725554,
+        "end_block_id": 135967856,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-08-09-20-eos-v6-135725554.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 135967856,
+        "end_block_id": 136209641,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-08-11-06-eos-v6-135967856.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 136209641,
+        "end_block_id": 136324447,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-08-12-16-eos-v6-136209641.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 136324447,
+        "end_block_id": 136554850,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-08-13-07-eos-v6-136324447.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 136554850,
+        "end_block_id": 136785783,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-08-14-15-eos-v6-136554850.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 136785783,
+        "end_block_id": 136900173,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-08-16-00-eos-v6-136785783.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 136900173,
+        "end_block_id": 137168833,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-08-16-15-eos-v6-136900173.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 137168833,
+        "end_block_id": 137425128,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-08-18-05-eos-v6-137168833.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 137425128,
+        "end_block_id": 137438144,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-08-19-16-eos-v6-137425128.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 137438144,
+        "end_block_id": 137706738,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-08-19-18-eos-v6-137438144.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 137706738,
+        "end_block_id": 137974955,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-08-21-08-eos-v6-137706738.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 137974955,
+        "end_block_id": 138109789,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-08-22-21-eos-v6-137974955.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 138109789,
+        "end_block_id": 138239551,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-08-23-16-eos-v6-138109789.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 138239551,
+        "end_block_id": 138369197,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-08-24-10-eos-v6-138239551.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 138369197,
+        "end_block_id": 138499145,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-08-25-04-eos-v6-138369197.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 138499145,
+        "end_block_id": 138628385,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-08-25-22-eos-v6-138499145.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 138628385,
+        "end_block_id": 138748546,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-08-26-16-eos-v6-138628385.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 138748546,
+        "end_block_id": 138870183,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-08-27-08-eos-v6-138748546.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 138870183,
+        "end_block_id": 138991185,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-08-28-01-eos-v6-138870183.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 138991185,
+        "end_block_id": 139111742,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-08-28-18-eos-v6-138991185.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 139111742,
+        "end_block_id": 139232424,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-08-29-11-eos-v6-139111742.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 139232424,
+        "end_block_id": 139232461,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-08-30-04-eos-v6-139232424.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 139232461,
+        "end_block_id": 139353620,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-08-30-04-eos-v6-139232461.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 139353620,
+        "end_block_id": 139474692,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-08-30-20-eos-v6-139353620.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 139474692,
+        "end_block_id": 139595555,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-08-31-13-eos-v6-139474692.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 139595555,
+        "end_block_id": 139716319,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-09-01-06-eos-v6-139595555.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 139716319,
+        "end_block_id": 139836604,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-09-01-23-eos-v6-139716319.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 139836604,
+        "end_block_id": 139974398,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-09-02-15-eos-v6-139836604.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 139974398,
+        "end_block_id": 140113095,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-09-03-11-eos-v6-139974398.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 140113095,
+        "end_block_id": 140389608,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-09-04-06-eos-v6-140113095.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 140389608,
+        "end_block_id": 140526413,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-09-05-20-eos-v6-140389608.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 140526413,
+        "end_block_id": 140794904,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-09-06-15-eos-v6-140526413.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 140794904,
+        "end_block_id": 141064286,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-09-08-05-eos-v6-140794904.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 141064286,
+        "end_block_id": 141198974,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-09-09-18-eos-v6-141064286.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 141198974,
+        "end_block_id": 141468029,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-09-10-13-eos-v6-141198974.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 141468029,
+        "end_block_id": 141735500,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-09-12-02-eos-v6-141468029.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 141735500,
+        "end_block_id": 141865994,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-09-13-15-eos-v6-141735500.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 141865994,
+        "end_block_id": 142124485,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-09-14-10-eos-v6-141865994.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 142124485,
+        "end_block_id": 142389042,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-09-15-21-eos-v6-142124485.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 142389042,
+        "end_block_id": 142523783,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-09-17-10-eos-v6-142389042.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 142523783,
+        "end_block_id": 142791591,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-09-18-05-eos-v6-142523783.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 142791591,
+        "end_block_id": 143060782,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-09-19-18-eos-v6-142791591.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 143060782,
+        "end_block_id": 143195317,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-09-21-08-eos-v6-143060782.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 143195317,
+        "end_block_id": 143464105,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-09-22-02-eos-v6-143195317.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 143464105,
+        "end_block_id": 143739850,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-09-23-16-eos-v6-143464105.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 143739850,
+        "end_block_id": 143878238,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-09-25-06-eos-v6-143739850.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 143878238,
+        "end_block_id": 144155403,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-09-26-01-eos-v6-143878238.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 144155403,
+        "end_block_id": 144457289,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-09-27-16-eos-v6-144155403.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 144457289,
+        "end_block_id": 144608498,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-09-29-10-eos-v6-144457289.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 144608498,
+        "end_block_id": 144911338,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-09-30-07-eos-v6-144608498.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 144911338,
+        "end_block_id": 145213713,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-10-02-01-eos-v6-144911338.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 145213713,
+        "end_block_id": 145365072,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-10-03-19-eos-v6-145213713.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 145365072,
+        "end_block_id": 145709970,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-10-04-16-eos-v6-145365072.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 145709970,
+        "end_block_id": 145883925,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-10-06-15-eos-v6-145709970.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 145883925,
+        "end_block_id": 146185404,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-10-07-16-eos-v6-145883925.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 146185404,
+        "end_block_id": 146487913,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-10-09-10-eos-v6-146185404.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 146487913,
+        "end_block_id": 146638296,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-10-11-04-eos-v6-146487913.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 146638296,
+        "end_block_id": 146941043,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-10-12-00-eos-v6-146638296.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 146941043,
+        "end_block_id": 147265125,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-10-13-19-eos-v6-146941043.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 147265125,
+        "end_block_id": 147437700,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-10-15-16-eos-v6-147265125.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 147437700,
+        "end_block_id": 147783462,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-10-16-16-eos-v6-147437700.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 147783462,
+        "end_block_id": 148084841,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-10-18-16-eos-v6-147783462.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 148084841,
+        "end_block_id": 148236587,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-10-20-09-eos-v6-148084841.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 148236587,
+        "end_block_id": 148538366,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-10-21-07-eos-v6-148236587.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 148538366,
+        "end_block_id": 148840611,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-10-23-01-eos-v6-148538366.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 148840611,
+        "end_block_id": 148991245,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-10-24-19-eos-v6-148840611.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 148991245,
+        "end_block_id": 149336293,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-10-25-15-eos-v6-148991245.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 149336293,
+        "end_block_id": 149508591,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-10-27-15-eos-v6-149336293.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 149508591,
+        "end_block_id": 149812215,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-10-28-15-eos-v6-149508591.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 149812215,
+        "end_block_id": 150114277,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-10-30-10-eos-v6-149812215.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 150114277,
+        "end_block_id": 150265646,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-11-01-04-eos-v6-150114277.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 150265646,
+        "end_block_id": 150567910,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-11-02-01-eos-v6-150265646.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 150567910,
+        "end_block_id": 150891137,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-11-03-19-eos-v6-150567910.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 150891137,
+        "end_block_id": 151064640,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-11-05-15-eos-v6-150891137.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 151064640,
+        "end_block_id": 151409429,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-11-06-16-eos-v6-151064640.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 151409429,
+        "end_block_id": 151582117,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-11-08-16-eos-v6-151409429.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 151582117,
+        "end_block_id": 151927859,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-11-09-15-eos-v6-151582117.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 151927859,
+        "end_block_id": 152272878,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-11-11-16-eos-v6-151927859.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 152272878,
+        "end_block_id": 152446160,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-11-13-15-eos-v6-152272878.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 152446160,
+        "end_block_id": 152748310,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-11-14-16-eos-v6-152446160.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 152748310,
+        "end_block_id": 153006255,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-11-16-10-eos-v6-152748310.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 153006255,
+        "end_block_id": 153136151,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-11-17-21-eos-v6-153006255.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 153136151,
+        "end_block_id": 153404321,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-11-18-16-eos-v6-153136151.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 153404321,
+        "end_block_id": 153674374,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-11-20-05-eos-v6-153404321.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 153674374,
+        "end_block_id": 153807828,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-11-21-18-eos-v6-153674374.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 153807828,
+        "end_block_id": 154077294,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-11-22-13-eos-v6-153807828.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 154077294,
+        "end_block_id": 154345892,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-11-24-02-eos-v6-154077294.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 154345892,
+        "end_block_id": 154483399,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-11-25-16-eos-v6-154345892.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 154483399,
+        "end_block_id": 154760361,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-11-26-11-eos-v6-154483399.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 154760361,
+        "end_block_id": 155036882,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-11-28-01-eos-v6-154760361.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 155036882,
+        "end_block_id": 155170264,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-11-29-16-eos-v6-155036882.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 155170264,
+        "end_block_id": 155439632,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-11-30-10-eos-v6-155170264.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 155439632,
+        "end_block_id": 155709050,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-12-02-00-eos-v6-155439632.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 155709050,
+        "end_block_id": 155841964,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-12-03-13-eos-v6-155709050.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 155841964,
+        "end_block_id": 156110739,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-12-04-07-eos-v6-155841964.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 156110739,
+        "end_block_id": 156375201,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-12-05-21-eos-v6-156110739.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 156375201,
+        "end_block_id": 156504025,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-12-07-10-eos-v6-156375201.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 156504025,
+        "end_block_id": 156763385,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-12-08-03-eos-v6-156504025.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 156763385,
+        "end_block_id": 157032013,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-12-09-16-eos-v6-156763385.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 157032013,
+        "end_block_id": 157166208,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-12-11-05-eos-v6-157032013.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 157166208,
+        "end_block_id": 157434014,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-12-12-00-eos-v6-157166208.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 157434014,
+        "end_block_id": 157702662,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-12-13-13-eos-v6-157434014.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 157702662,
+        "end_block_id": 157837113,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-12-15-02-eos-v6-157702662.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 157837113,
+        "end_block_id": 158109309,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-12-15-21-eos-v6-157837113.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 158109309,
+        "end_block_id": 158385849,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-12-17-11-eos-v6-158109309.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 158385849,
+        "end_block_id": 158525032,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-12-19-01-eos-v6-158385849.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 158525032,
+        "end_block_id": 158796618,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-12-19-20-eos-v6-158525032.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 158796618,
+        "end_block_id": 159066400,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-12-21-10-eos-v6-158796618.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 159066400,
+        "end_block_id": 159200752,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-12-23-00-eos-v6-159066400.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 159200752,
+        "end_block_id": 159468535,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-12-23-18-eos-v6-159200752.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 159468535,
+        "end_block_id": 159737432,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-12-25-07-eos-v6-159468535.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 159737432,
+        "end_block_id": 159871557,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-12-26-21-eos-v6-159737432.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 159871557,
+        "end_block_id": 160131225,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-12-27-15-eos-v6-159871557.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 160131225,
+        "end_block_id": 160390221,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-12-29-04-eos-v6-160131225.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 160390221,
+        "end_block_id": 160524876,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-12-30-15-eos-v6-160390221.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 160524876,
+        "end_block_id": 160793088,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2020-12-31-10-eos-v6-160524876.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 160793088,
+        "end_block_id": 161061657,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-01-02-00-eos-v6-160793088.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 161061657,
+        "end_block_id": 161195900,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-01-03-13-eos-v6-161061657.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 161195900,
+        "end_block_id": 161464834,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-01-04-08-eos-v6-161195900.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 161464834,
+        "end_block_id": 161736338,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-01-05-21-eos-v6-161464834.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 161736338,
+        "end_block_id": 161875536,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-01-07-11-eos-v6-161736338.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 161875536,
+        "end_block_id": 162151981,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-01-08-06-eos-v6-161875536.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 162151981,
+        "end_block_id": 162423919,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-01-09-20-eos-v6-162151981.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 162423919,
+        "end_block_id": 162558499,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-01-11-10-eos-v6-162423919.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 162558499,
+        "end_block_id": 162827587,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-01-12-05-eos-v6-162558499.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 162827587,
+        "end_block_id": 163095987,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-01-13-18-eos-v6-162827587.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 163095987,
+        "end_block_id": 163230247,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-01-15-08-eos-v6-163095987.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 163230247,
+        "end_block_id": 163498911,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-01-16-02-eos-v6-163230247.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 163498911,
+        "end_block_id": 163628207,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-01-17-15-eos-v6-163498911.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 163628207,
+        "end_block_id": 163757966,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-01-18-09-eos-v6-163628207.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 163757966,
+        "end_block_id": 164152222,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-01-19-03-eos-v6-163757966.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 164152222,
+        "end_block_id": 164285972,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-01-21-10-eos-v6-164152222.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 164285972,
+        "end_block_id": 164554539,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-01-22-05-eos-v6-164285972.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 164554539,
+        "end_block_id": 164823078,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-01-23-18-eos-v6-164554539.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 164823078,
+        "end_block_id": 164957433,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-01-25-07-eos-v6-164823078.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 164957433,
+        "end_block_id": 165226483,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-01-26-02-eos-v6-164957433.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 165226483,
+        "end_block_id": 165503019,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-01-27-16-eos-v6-165226483.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 165503019,
+        "end_block_id": 165640738,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-01-29-06-eos-v6-165503019.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 165640738,
+        "end_block_id": 165917430,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-01-30-01-eos-v6-165640738.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 165917430,
+        "end_block_id": 166219009,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-01-31-16-eos-v6-165917430.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 166219009,
+        "end_block_id": 166369908,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-02-02-10-eos-v6-166219009.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 166369908,
+        "end_block_id": 166670972,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-02-03-07-eos-v6-166369908.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 166670972,
+        "end_block_id": 166973881,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-02-05-01-eos-v6-166670972.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 166973881,
+        "end_block_id": 167124173,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-02-06-19-eos-v6-166973881.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 167124173,
+        "end_block_id": 167470089,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-02-07-15-eos-v6-167124173.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 167470089,
+        "end_block_id": 167641900,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-02-09-16-eos-v6-167470089.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 167641900,
+        "end_block_id": 167944687,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-02-10-15-eos-v6-167641900.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 167944687,
+        "end_block_id": 168247084,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-02-12-10-eos-v6-167944687.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 168247084,
+        "end_block_id": 168399001,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-02-14-04-eos-v6-168247084.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 168399001,
+        "end_block_id": 168700018,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-02-15-01-eos-v6-168399001.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 168700018,
+        "end_block_id": 169024472,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-02-16-18-eos-v6-168700018.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 169024472,
+        "end_block_id": 169197460,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-02-18-16-eos-v6-169024472.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 169197460,
+        "end_block_id": 169542680,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-02-19-16-eos-v6-169197460.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 169542680,
+        "end_block_id": 169713957,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-02-21-16-eos-v6-169542680.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 169713957,
+        "end_block_id": 170060263,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-02-22-15-eos-v6-169713957.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 170060263,
+        "end_block_id": 170232213,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-02-24-16-eos-v6-170060263.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 170232213,
+        "end_block_id": 170577608,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-02-25-16-eos-v6-170232213.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 170577608,
+        "end_block_id": 170750477,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-02-27-16-eos-v6-170577608.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 170750477,
+        "end_block_id": 171095898,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-02-28-16-eos-v6-170750477.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 171095898,
+        "end_block_id": 171268080,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-03-02-16-eos-v6-171095898.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 171268080,
+        "end_block_id": 171671842,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-03-03-16-eos-v6-171268080.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 171671842,
+        "end_block_id": 171873154,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-03-06-00-eos-v6-171671842.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 171873154,
+        "end_block_id": 172276638,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-03-07-04-eos-v6-171873154.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 172276638,
+        "end_block_id": 172477670,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-03-09-12-eos-v6-172276638.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 172477670,
+        "end_block_id": 172938667,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-03-10-16-eos-v6-172477670.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 172938667,
+        "end_block_id": 173168985,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-03-13-08-eos-v6-172938667.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 173168985,
+        "end_block_id": 173775202,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-03-14-16-eos-v6-173168985.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 173775202,
+        "end_block_id": 174074694,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-03-18-04-eos-v6-173775202.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 174074694,
+        "end_block_id": 174895903,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-03-19-22-eos-v6-174074694.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 174895903,
+        "end_block_id": 175299554,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-03-24-16-eos-v6-174895903.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 175299554,
+        "end_block_id": 176105089,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-03-27-00-eos-v6-175299554.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 176105089,
+        "end_block_id": 176795665,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-03-31-16-eos-v6-176105089.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 176795665,
+        "end_block_id": 177406896,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-04-04-16-eos-v6-176795665.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 177406896,
+        "end_block_id": 178008441,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-04-08-04-eos-v6-177406896.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 178008441,
+        "end_block_id": 178525960,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-04-11-16-eos-v6-178008441.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 178525960,
+        "end_block_id": 179128475,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-04-14-16-eos-v6-178525960.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 179128475,
+        "end_block_id": 179733736,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-04-18-04-eos-v6-179128475.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 179733736,
+        "end_block_id": 180420526,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-04-21-16-eos-v6-179733736.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 180420526,
+        "end_block_id": 181025958,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-04-25-16-eos-v6-180420526.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 181025958,
+        "end_block_id": 181630954,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-04-29-04-eos-v6-181025958.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 181630954,
+        "end_block_id": 182153451,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-05-02-16-eos-v6-181630954.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 182153451,
+        "end_block_id": 182755574,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-05-05-16-eos-v6-182153451.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 182755574,
+        "end_block_id": 183362871,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-05-09-04-eos-v6-182755574.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 183362871,
+        "end_block_id": 184048871,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-05-12-16-eos-v6-183362871.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 184048871,
+        "end_block_id": 185256817,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-05-16-16-eos-v6-184048871.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 185256817,
+        "end_block_id": 185781105,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-05-23-16-eos-v6-185256817.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 185781105,
+        "end_block_id": 186985365,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-05-26-17-eos-v6-185781105.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 186985365,
+        "end_block_id": 187678030,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-06-02-16-eos-v6-186985365.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 187678030,
+        "end_block_id": 188883588,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-06-06-16-eos-v6-187678030.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 188883588,
+        "end_block_id": 189406757,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-06-13-16-eos-v6-188883588.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 189406757,
+        "end_block_id": 190615532,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-06-16-16-eos-v6-189406757.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 190615532,
+        "end_block_id": 191302214,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-06-23-16-eos-v6-190615532.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 191302214,
+        "end_block_id": 192518700,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-06-27-16-eos-v6-191302214.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 192518700,
+        "end_block_id": 193028281,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-07-04-17-eos-v6-192518700.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 193028281,
+        "end_block_id": 193766947,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-07-07-16-eos-v6-193028281.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 193766947,
+        "end_block_id": 194931212,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-07-11-22-eos-v6-193766947.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 194931212,
+        "end_block_id": 196150408,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-07-18-16-eos-v6-194931212.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 196150408,
+        "end_block_id": 196663654,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-07-25-17-eos-v6-196150408.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 196663654,
+        "end_block_id": 197870490,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-07-28-17-eos-v6-196663654.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 197870490,
+        "end_block_id": 198558032,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-08-04-16-eos-v6-197870490.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 198558032,
+        "end_block_id": 199765882,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-08-08-16-eos-v6-198558032.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 199765882,
+        "end_block_id": 200289054,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-08-15-16-eos-v6-199765882.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 200289054,
+        "end_block_id": 201498264,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-08-18-16-eos-v6-200289054.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 201498264,
+        "end_block_id": 202187479,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-08-25-16-eos-v6-201498264.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 202187479,
+        "end_block_id": 203400888,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-08-29-16-eos-v6-202187479.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 203400888,
+        "end_block_id": 203911039,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-09-05-17-eos-v6-203400888.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 203911039,
+        "end_block_id": 205141387,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-09-08-16-eos-v6-203911039.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 205141387,
+        "end_block_id": 205812007,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-09-15-18-eos-v6-205141387.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 205812007,
+        "end_block_id": 207040017,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-09-19-16-eos-v6-205812007.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 207040017,
+        "end_block_id": 207554277,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-09-26-18-eos-v6-207040017.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 207554277,
+        "end_block_id": 208771330,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-09-29-18-eos-v6-207554277.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 208771330,
+        "end_block_id": 209444215,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-10-06-19-eos-v6-208771330.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 209444215,
+        "end_block_id": 210659568,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-10-10-16-eos-v6-209444215.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 210659568,
+        "end_block_id": 211186472,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-10-17-17-eos-v6-210659568.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 211186472,
+        "end_block_id": 212396720,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-10-20-18-eos-v6-211186472.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 212396720,
+        "end_block_id": 213073164,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-10-27-18-eos-v6-212396720.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 213073164,
+        "end_block_id": 214299849,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-10-31-16-eos-v6-213073164.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 214299849,
+        "end_block_id": 214810017,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-11-07-19-eos-v6-214299849.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 214810017,
+        "end_block_id": 216016166,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-11-10-18-eos-v6-214810017.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 216016166,
+        "end_block_id": 216712026,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-11-17-17-eos-v6-216016166.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 216712026,
+        "end_block_id": 217917348,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-11-21-18-eos-v6-216712026.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 217917348,
+        "end_block_id": 218428608,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-11-28-17-eos-v6-217917348.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 218428608,
+        "end_block_id": 219637494,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-12-01-16-eos-v6-218428608.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 219637494,
+        "end_block_id": 220351158,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-12-08-16-eos-v6-219637494.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 220351158,
+        "end_block_id": 221545509,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-12-12-20-eos-v6-220351158.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 221545509,
+        "end_block_id": 222066224,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-12-19-18-eos-v6-221545509.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 222066224,
+        "end_block_id": 223277304,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-12-22-18-eos-v6-222066224.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 223277304,
+        "end_block_id": 223955761,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2021-12-29-18-eos-v6-223277304.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 223955761,
+        "end_block_id": 225165839,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2022-01-02-17-eos-v6-223955761.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 225165839,
+        "end_block_id": 225698013,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2022-01-09-17-eos-v6-225165839.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 225698013,
+        "end_block_id": 226902111,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2022-01-12-19-eos-v6-225698013.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 226902111,
+        "end_block_id": 227600448,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2022-01-19-18-eos-v6-226902111.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 227600448,
+        "end_block_id": 228790004,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2022-01-23-19-eos-v6-227600448.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 228790004,
+        "end_block_id": 229325504,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2022-01-30-16-eos-v6-228790004.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 229325504,
+        "end_block_id": 230527720,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2022-02-02-19-eos-v6-229325504.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 230527720,
+        "end_block_id": 231216077,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2022-02-09-18-eos-v6-230527720.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 231216077,
+        "end_block_id": 232441879,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2022-02-13-17-eos-v6-231216077.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 232441879,
+        "end_block_id": 234156243,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2022-02-20-20-eos-v6-232441879.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 234156243,
+        "end_block_id": 234836497,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2022-03-02-18-eos-v6-234156243.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 234836497,
+        "end_block_id": 236054754,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2022-03-06-16-eos-v6-234836497.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 236054754,
+        "end_block_id": 236575041,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2022-03-13-18-eos-v6-236054754.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 236575041,
+        "end_block_id": 237780792,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2022-03-16-18-eos-v6-236575041.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 237780792,
+        "end_block_id": 238488325,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2022-03-23-17-eos-v6-237780792.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 238488325,
+        "end_block_id": 239671238,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2022-03-27-20-eos-v6-238488325.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 239671238,
+        "end_block_id": 240206158,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2022-04-03-16-eos-v6-239671238.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 240206158,
+        "end_block_id": 241413609,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2022-04-06-18-eos-v6-240206158.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 241413609,
+        "end_block_id": 242093053,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2022-04-13-18-eos-v6-241413609.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 242093053,
+        "end_block_id": 243326292,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2022-04-17-16-eos-v6-242093053.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 243326292,
+        "end_block_id": 245050633,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2022-04-24-20-eos-v6-243326292.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 245050633,
+        "end_block_id": 245734567,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2022-05-04-19-eos-v6-245050633.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 245734567,
+        "end_block_id": 246964464,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2022-05-08-18-eos-v6-245734567.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 246964464,
+        "end_block_id": 248655465,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2022-05-15-21-eos-v6-246964464.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 248655465,
+        "end_block_id": 249353704,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2022-05-25-16-eos-v6-248655465.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 249353704,
+        "end_block_id": 250577757,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2022-05-29-17-eos-v6-249353704.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 250577757,
+        "end_block_id": 251099936,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2022-06-05-19-eos-v6-250577757.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 251099936,
+        "end_block_id": 252287069,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2022-06-08-20-eos-v6-251099936.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 252287069,
+        "end_block_id": 252972890,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2022-06-15-17-eos-v6-252287069.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 252972890,
+        "end_block_id": 254208471,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2022-06-19-16-eos-v6-252972890.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 254208471,
+        "end_block_id": 254729456,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2022-06-26-20-eos-v6-254208471.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 254729456,
+        "end_block_id": 255913999,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2022-06-29-20-eos-v6-254729456.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 255913999,
+        "end_block_id": 256619649,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2022-07-06-17-eos-v6-255913999.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 256619649,
+        "end_block_id": 257820642,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2022-07-10-19-eos-v6-256619649.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 257820642,
+        "end_block_id": 258340380,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2022-07-17-17-eos-v6-257820642.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 258340380,
+        "end_block_id": 259561451,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2022-07-20-18-eos-v6-258340380.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 259561451,
+        "end_block_id": 260236399,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2022-07-27-19-eos-v6-259561451.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 260236399,
+        "end_block_id": 261452212,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2022-07-31-17-eos-v6-260236399.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 261452212,
+        "end_block_id": 261957265,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2022-08-07-18-eos-v6-261452212.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 261957265,
+        "end_block_id": 263168252,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2022-08-10-16-eos-v6-261957265.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 263168252,
+        "end_block_id": 263861288,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2022-08-17-17-eos-v6-263168252.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 263861288,
+        "end_block_id": 265088617,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2022-08-21-17-eos-v6-263861288.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 265088617,
+        "end_block_id": 266797351,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2022-08-28-19-eos-v6-265088617.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 266797351,
+        "end_block_id": 267500807,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2022-09-07-17-eos-v6-266797351.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 267500807,
+        "end_block_id": 268707926,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2022-09-11-19-eos-v6-267500807.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 268707926,
+        "end_block_id": 269226900,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2022-09-18-18-eos-v6-268707926.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 269226900,
+        "end_block_id": 270439512,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2022-09-21-19-eos-v6-269226900.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 270439512,
+        "end_block_id": 271116049,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2022-09-28-19-eos-v6-270439512.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 271116049,
+        "end_block_id": 271699658,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2022-10-02-17-eos-v6-271116049.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 271699658,
+        "end_block_id": 272831956,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2022-10-06-03-eos-v6-271699658.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 272831956,
+        "end_block_id": 274052114,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2022-10-12-16-eos-v6-272831956.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 274052114,
+        "end_block_id": 274730730,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2022-10-19-18-eos-v6-274052114.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 274730730,
+        "end_block_id": 275959495,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2022-10-23-16-eos-v6-274730730.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 275959495,
+        "end_block_id": 276462692,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2022-10-30-19-eos-v6-275959495.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 276462692,
+        "end_block_id": 277682198,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2022-11-02-17-eos-v6-276462692.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 277682198,
+        "end_block_id": 278367454,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2022-11-09-18-eos-v6-277682198.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 278367454,
+        "end_block_id": 279582695,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2022-11-13-17-eos-v6-278367454.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 279582695,
+        "end_block_id": 280096963,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2022-11-20-18-eos-v6-279582695.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 280096963,
+        "end_block_id": 281310673,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2022-11-23-18-eos-v6-280096963.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 281310673,
+        "end_block_id": 282003675,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2022-11-30-18-eos-v6-281310673.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 282003675,
+        "end_block_id": 283191585,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2022-12-04-19-eos-v6-282003675.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 283191585,
+        "end_block_id": 283719683,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2022-12-11-16-eos-v6-283191585.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 283719683,
+        "end_block_id": 284934241,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2022-12-14-17-eos-v6-283719683.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 284934241,
+        "end_block_id": 285619451,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2022-12-21-18-eos-v6-284934241.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 285619451,
+        "end_block_id": 286846327,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2022-12-25-17-eos-v6-285619451.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 286846327,
+        "end_block_id": 287352379,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2023-01-01-19-eos-v6-286846327.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 287352379,
+        "end_block_id": 288550792,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2023-01-04-18-eos-v6-287352379.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 288550792,
+        "end_block_id": 289239853,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2023-01-11-16-eos-v6-288550792.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 289239853,
+        "end_block_id": 290461088,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2023-01-15-16-eos-v6-289239853.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 290461088,
+        "end_block_id": 290979668,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2023-01-22-18-eos-v6-290461088.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 290979668,
+        "end_block_id": 292194694,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2023-01-25-18-eos-v6-290979668.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 292194694,
+        "end_block_id": 292882437,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2023-02-01-19-eos-v6-292194694.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 292882437,
+        "end_block_id": 294087235,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2023-02-05-18-eos-v6-292882437.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 294087235,
+        "end_block_id": 294611291,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2023-02-12-18-eos-v6-294087235.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 294611291,
+        "end_block_id": 295806529,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2023-02-15-18-eos-v6-294611291.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 295806529,
+        "end_block_id": 296491360,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2023-02-22-16-eos-v6-295806529.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 296491360,
+        "end_block_id": 297711513,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2023-02-26-16-eos-v6-296491360.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 297711513,
+        "end_block_id": 298221449,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2023-03-05-18-eos-v6-297711513.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 298221449,
+        "end_block_id": 299428095,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2023-03-08-16-eos-v6-298221449.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 299428095,
+        "end_block_id": 300119580,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2023-03-15-16-eos-v6-299428095.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 300119580,
+        "end_block_id": 301347248,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2023-03-19-16-eos-v6-300119580.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 301347248,
+        "end_block_id": 303073294,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2023-03-26-19-eos-v6-301347248.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 303073294,
+        "end_block_id": 303774605,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2023-04-05-18-eos-v6-303073294.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 303774605,
+        "end_block_id": 304954287,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2023-04-09-20-eos-v6-303774605.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 304954287,
+        "end_block_id": 305481896,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2023-04-16-16-eos-v6-304954287.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 305481896,
+        "end_block_id": 306685206,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2023-04-19-17-eos-v6-305481896.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 306685206,
+        "end_block_id": 307391649,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2023-04-26-16-eos-v6-306685206.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 307391649,
+        "end_block_id": 308586233,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2023-04-30-18-eos-v6-307391649.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 308586233,
+        "end_block_id": 309116867,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2023-05-07-16-eos-v6-308586233.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 309116867,
+        "end_block_id": 310310194,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2023-05-10-18-eos-v6-309116867.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 310310194,
+        "end_block_id": 311005264,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2023-05-17-16-eos-v6-310310194.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 311005264,
+        "end_block_id": 312222278,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2023-05-21-16-eos-v6-311005264.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 312222278,
+        "end_block_id": 312744132,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2023-05-28-17-eos-v6-312222278.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 312744132,
+        "end_block_id": 313958847,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2023-05-31-18-eos-v6-312744132.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 313958847,
+        "end_block_id": 314630511,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2023-06-07-18-eos-v6-313958847.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 314630511,
+        "end_block_id": 315844411,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2023-06-11-16-eos-v6-314630511.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 315844411,
+        "end_block_id": 316388380,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2023-06-18-16-eos-v6-315844411.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 316388380,
+        "end_block_id": 317566938,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2023-06-21-20-eos-v6-316388380.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 317566938,
+        "end_block_id": 318279344,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2023-06-28-16-eos-v6-317566938.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 318279344,
+        "end_block_id": 319489553,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2023-07-02-19-eos-v6-318279344.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 319489553,
+        "end_block_id": 320009600,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2023-07-09-19-eos-v6-319489553.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 320009600,
+        "end_block_id": 321193208,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2023-07-12-19-eos-v6-320009600.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 321193208,
+        "end_block_id": 321913344,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2023-07-19-16-eos-v6-321193208.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 321913344,
+        "end_block_id": 323120518,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2023-07-23-20-eos-v6-321913344.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 323120518,
+        "end_block_id": 323642042,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2023-07-30-19-eos-v6-323120518.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 323642042,
+        "end_block_id": 324828648,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2023-08-02-20-eos-v6-323642042.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 324828648,
+        "end_block_id": 325534911,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2023-08-09-17-eos-v6-324828648.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 325534911,
+        "end_block_id": 326721406,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2023-08-13-19-eos-v6-325534911.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 326721406,
+        "end_block_id": 327250483,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2023-08-20-16-eos-v6-326721406.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 327250483,
+        "end_block_id": 328473089,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2023-08-23-17-eos-v6-327250483.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 328473089,
+        "end_block_id": 329156481,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2023-08-30-19-eos-v6-328473089.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 329156481,
+        "end_block_id": 330383676,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2023-09-03-18-eos-v6-329156481.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 330383676,
+        "end_block_id": 330893038,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2023-09-10-21-eos-v6-330383676.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 330893038,
+        "end_block_id": 332103067,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2023-09-13-19-eos-v6-330893038.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 332103067,
+        "end_block_id": 333982732,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2023-09-20-20-eos-v6-332103067.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 333982732,
+        "end_block_id": 334515773,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2023-10-01-17-eos-v6-333982732.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 334515773,
+        "end_block_id": 335712513,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2023-10-04-19-eos-v6-334515773.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 335712513,
+        "end_block_id": 336419097,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2023-10-11-17-eos-v6-335712513.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 336419097,
+        "end_block_id": 337608758,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2023-10-15-19-eos-v6-336419097.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 337608758,
+        "end_block_id": 338124056,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2023-10-22-16-eos-v6-337608758.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 338124056,
+        "end_block_id": 339330410,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2023-10-25-16-eos-v6-338124056.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 339330410,
+        "end_block_id": 340024696,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2023-11-01-16-eos-v6-339330410.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 340024696,
+        "end_block_id": 340715330,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2023-11-05-16-eos-v6-340024696.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 340715330,
+        "end_block_id": 341057316,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2023-11-09-16-eos-v6-340715330.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 341057316,
+        "end_block_id": 341577175,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2023-11-11-16-eos-v6-341057316.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 341577175,
+        "end_block_id": 341923798,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2023-11-14-16-eos-v6-341577175.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 341923798,
+        "end_block_id": 342442902,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2023-11-16-16-eos-v6-341923798.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 342442902,
+        "end_block_id": 342799469,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2023-11-19-16-eos-v6-342442902.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 342799469,
+        "end_block_id": 343491443,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2023-11-21-18-eos-v6-342799469.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 343491443,
+        "end_block_id": 343990663,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2023-11-25-18-eos-v6-343491443.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 343990663,
+        "end_block_id": 344672571,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2023-11-28-15-eos-v6-343990663.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 344672571,
+        "end_block_id": 345005951,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2023-12-02-14-eos-v6-344672571.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 345005951,
+        "end_block_id": 345686101,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2023-12-04-12-eos-v6-345005951.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 345686101,
+        "end_block_id": 346025446,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2023-12-08-11-eos-v6-345686101.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 346025446,
+        "end_block_id": 346727979,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2023-12-10-10-eos-v6-346025446.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 346727979,
+        "end_block_id": 347054004,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2023-12-14-11-eos-v6-346727979.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 347054004,
+        "end_block_id": 347737033,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2023-12-16-09-eos-v6-347054004.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 347737033,
+        "end_block_id": 348083350,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2023-12-20-08-eos-v6-347737033.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 348083350,
+        "end_block_id": 348765026,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2023-12-22-08-eos-v6-348083350.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 348765026,
+        "end_block_id": 349106963,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2023-12-26-07-eos-v6-348765026.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    },
+    {
+        "start_block_id": 349106963,
+        "end_block_id": 349798134,
+        "snapshot_path": "s3://chicken-dance/mainnet/snapshots/snapshot-2023-12-28-06-eos-v6-349106963.bin.zst",
+        "storage_type": "s3",
+        "expected_integrity_hash": "",
+        "leap_version": "5.0.2"
+    }
+]

--- a/scripts/manifest/generate_manifest.py
+++ b/scripts/manifest/generate_manifest.py
@@ -128,7 +128,7 @@ class BuildSnapshotsFromS3: # pylint: disable=too-few-public-methods
 
     def get_urls(self):
         """builds a list of URLs from snapshots in S3 Bucket"""
-        logging.debug(f"s3 path {S3Interface.build_s3_loc(self.bucket,self.snap_dir+'/snapshots/')}")
+        logging.debug("s3 path %s", S3Interface.build_s3_loc(self.bucket,self.snap_dir+'/snapshots/'))
         snaps_list  = S3Interface.list(self.bucket, self.snap_dir +'/snapshots/', True)
         url_list = []
         # add one fake snapshot for genesis

--- a/scripts/manifest/generate_manifest.py
+++ b/scripts/manifest/generate_manifest.py
@@ -128,7 +128,8 @@ class BuildSnapshotsFromS3: # pylint: disable=too-few-public-methods
 
     def get_urls(self):
         """builds a list of URLs from snapshots in S3 Bucket"""
-        logging.debug("s3 path %s", S3Interface.build_s3_loc(self.bucket,self.snap_dir+'/snapshots/'))
+        logging.debug("s3 path %s",
+            S3Interface.build_s3_loc(self.bucket,self.snap_dir+'/snapshots/'))
         snaps_list  = S3Interface.list(self.bucket, self.snap_dir +'/snapshots/', True)
         url_list = []
         # add one fake snapshot for genesis

--- a/scripts/manifest/generate_manifest.py
+++ b/scripts/manifest/generate_manifest.py
@@ -6,11 +6,13 @@ import subprocess
 import argparse
 import logging
 import requests
+from s3Interface import S3Interface
 from bs4 import BeautifulSoup
 
-# 1 - Connect to web page and parse out list of snapshots
+# 1 - Connect to S3 and parse out list of snapshots
+#   - Alternatively connect to web page and parse out list of snapshots
 # 2 - process list and create data structure, snapshot_manifest
-# python3.10 generate_manifest_from_eosnation.py --source-net mainnet --leap-version 5.0.0-rc2
+# python3.10 generate_manifest_from_eosnation.py --source-net mainnet --leap-version 5.0.2
 
 class ParseSnapshots:
     """Parse HTML page with list of snapshots"""
@@ -95,7 +97,8 @@ class ParseSnapshots:
         url_list.append("https://ops.store.eosnation.io/eos-snapshots/snapshot-2018-06-10-01-eos-v6-0000000000.bin.zst") # pylint: disable=line-too-long
         return url_list
 
-    def filter_by_block_range(self, snapshots, min_block_num, max_block_num):
+    @staticmethod
+    def filter_by_block_range(snapshots, min_block_num, max_block_num):
         """filter out snapshots outside the given range"""
         index = 0
         number_of_snapshots = len(snapshots)
@@ -116,6 +119,24 @@ class ParseSnapshots:
             index += 1
 
         return filter_snapshots
+
+class BuildSnapshotsFromS3: # pylint: disable=too-few-public-methods
+    """Build URL list of snapshots from S3 repo"""
+    def __init__(self, bucket, snap_dir):
+        self.bucket = bucket
+        self.snap_dir = snap_dir
+
+    def get_urls(self):
+        """builds a list of URLs from snapshots in S3 Bucket"""
+        logging.debug(f"s3 path {S3Interface.build_s3_loc(self.bucket,self.snap_dir+'/snapshots/')}")
+        snaps_list  = S3Interface.list(self.bucket, self.snap_dir +'/snapshots/', True)
+        url_list = []
+        # add one fake snapshot for genesis
+        url_list.append("https://eosio.null.com/chicken/snapshot-2018-06-10-01-eos-v6-0000000000.bin.zst") # pylint: disable=line-too-long
+        for snapshot in snaps_list:
+            url_list.append("https://eosio.null.com/chicken/"+snapshot)
+        return url_list
+
 
 class Manifest:
     """Builds manifest and prints json config from list of snapshots"""
@@ -335,6 +356,8 @@ if __name__ == '__main__':
         help='version of snapshot, default v6')
     parser.add_argument('--leap-version', type=str, default='5.0.0',
         help='version of leap, default 5.0.0')
+    parser.add_argument('--source-eosnation', action=argparse.BooleanOptionalAction, \
+        default=False, help='build snapshots from eosnation snapshots list')
     parser.add_argument('--block-space-between-slices', type=int, default=500000, \
         help='min number of blocks between slices, cuts down on the number of slices created')
     parser.add_argument('--upload-snapshots', action=argparse.BooleanOptionalAction, \
@@ -353,25 +376,34 @@ if __name__ == '__main__':
     else:
         logging.basicConfig(level=logging.ERROR)
 
-    search_title = f"{args.source_net} - {args.snapshot_version}"
-    if args.source_net.lower() == "mainnet":
-        search_title = f"EOS Mainnet - {args.snapshot_version}"
-    if "jungle" in args.source_net.lower():
-        search_title = f"Jungle 4 Testnet - {args.snapshot_version}"
-    if "kylin" in args.source_net.lower():
-        search_title = f"Kylin Testnet - {args.snapshot_version}"
+    list_of_snapshots = []
+    # execute code to source snapshot list from eosnation
+    # otherwise default is to pull snapshot list from S3 snapshot
+    if args.source_eosnation:
+        search_title = f"{args.source_net} - {args.snapshot_version}"
+        if args.source_net.lower() == "mainnet":
+            search_title = f"EOS Mainnet - {args.snapshot_version}"
+        if "jungle" in args.source_net.lower():
+            search_title = f"Jungle 4 Testnet - {args.snapshot_version}"
+        if "kylin" in args.source_net.lower():
+            search_title = f"Kylin Testnet - {args.snapshot_version}"
 
-    parser = ParseSnapshots("https://snapshots.eosnation.io/", search_title)
-    list_of_snapshots = parser.get_content()
+        parser = ParseSnapshots("https://snapshots.eosnation.io/", search_title)
+
+    else:
+        builder = BuildSnapshotsFromS3("chicken-dance",args.source_net.lower())
+        list_of_snapshots = builder.get_urls()
+
     # filter only when max or min defined
     if args.min_block_height or args.max_block_height:
-        list_of_snapshots = parser.filter_by_block_range(
+        list_of_snapshots = ParseSnapshots.filter_by_block_range(
             list_of_snapshots,
             args.min_block_height,
             args.max_block_height
         )
     else:
         logging.debug("FILTER: no filter to run")
+
     # hmm something went wrong
     if not list_of_snapshots:
         logging.error("Failed to match, no sources found")


### PR DESCRIPTION
Update python code to generate a manifest from S3 snapshot list. This PR included an update to the full manifest meta-data up to Jan 2024, and updated documentation. 